### PR TITLE
Fix Long file mode in assembly configuration

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 AquaQ Analytics Limited
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.github.sranka</groupId>
   <artifactId>jdbcimage</artifactId>
   <name>JDBC Image Tool</name>
-  <version>0.6-SNAPSHOT</version>
+  <version>0.7-SNAPSHOT</version>
   <build>
     <plugins>
       <plugin>
@@ -56,6 +56,7 @@
                 <descriptor>src/main/assembly/assembly.xml</descriptor>
               </descriptors>
               <encoding>UTF-8</encoding>
+              <tarLongFileMode>posix</tarLongFileMode>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
 								<descriptor>src/main/assembly/assembly.xml</descriptor>
 							</descriptors>
 							<encoding>UTF-8</encoding>
+							<tarLongFileMode>posix</tarLongFileMode>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
without the `tarLongFileMod=posix`, `mvn install` fails with the following error
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.0.0:single (make-assembly) on project jdbcimage: Execution make-assembly of goal org.apache.maven.plugins:maven-assembly-plugin:3.0.0:single failed: group id '1569954282' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit -> [Help 1]
```