### PR TITLE
Update jdbcimage.bat to fix issue #5

### DIFF
--- a/jdbcimage.bat
+++ b/jdbcimage.bat
@@ -1,4 +1,4 @@
 @setlocal
 @echo off
 set JAVA_OPTS=-Xmx1024m
-java %JAVA_OPTS% -classpath ""%~dp0target/jdbcimage.jar;%~dp0lib/*" pz.tool.jdbcimage.main.JdbcImageMain %*
+java %JAVA_OPTS% -classpath "%~dp0target/jdbcimage.jar;%~dp0lib/*" pz.tool.jdbcimage.main.JdbcImageMain %*


### PR DESCRIPTION
Removes the extra double quote to fix issue #5 and allow `jdbcimage.bat` to execute in Windows. Tested that the change allows execution to begin as expected on Windows 10.