### PR TITLE
fix(mssql): automatically set identity_insert only when inserting to identity column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,17 @@
 			<artifactId>commons-dbcp2</artifactId>
 			<version>2.1.1</version>
 		</dependency>
+		<!-- logging -->
+		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+			<version>1.2</version>
+		</dependency>
 		<!-- tests -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/pz/tool/jdbcimage/db/DbImportResultConsumer.java
+++ b/src/main/java/pz/tool/jdbcimage/db/DbImportResultConsumer.java
@@ -12,6 +12,7 @@ import java.io.Reader;
 import java.math.BigDecimal;
 import java.sql.*;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Import pushed data into a database.
@@ -24,6 +25,8 @@ public class DbImportResultConsumer implements ResultConsumer<RowData>{
     private final Connection con;
     private final DBFacade db;
     private final Map<String,String> actualColumns;
+    private Consumer<ResultSetInfo> notifyOnStartFn = (r) -> {};
+
 
     // initialize in on start
     private PreparedStatement stmt = null;
@@ -50,8 +53,13 @@ public class DbImportResultConsumer implements ResultConsumer<RowData>{
         this.actualColumns = actualColumns;
     }
 
+    public void setNotifyOnStartFn(Consumer<ResultSetInfo> consumer){
+        this.notifyOnStartFn = consumer;
+    }
+
     @Override
     public void onStart(ResultSetInfo info) {
+        this.notifyOnStartFn.accept(info);
         // set connection to info, so blobs can be serialized without extra resources
         if (this.db.canCreateBlobs()){
             info.connection = con;

--- a/src/main/java/pz/tool/jdbcimage/main/DBFacade.java
+++ b/src/main/java/pz/tool/jdbcimage/main/DBFacade.java
@@ -15,6 +15,7 @@ import java.util.stream.Stream;
 import org.apache.commons.dbcp2.BasicDataSource;
 
 import pz.tool.jdbcimage.LoggedUtils;
+import pz.tool.jdbcimage.ResultSetInfo;
 
 /**
  * Facade that isolates specifics of a particular database
@@ -213,6 +214,11 @@ public abstract class DBFacade implements DBFacadeListener{
     public void beforeImportTable(Connection con, String table, TableInfo tableInfo) throws SQLException{
         for (DBFacadeListener l: listeners) {
             l.beforeImportTable(con, table, tableInfo);
+        }
+    }
+    public void beforeImportTableData(Connection con, String table, TableInfo tableInfo, ResultSetInfo fileInfo) throws SQLException{
+        for (DBFacadeListener l: listeners) {
+            l.beforeImportTableData(con, table, tableInfo, fileInfo);
         }
     }
     public void afterImportTable(Connection con, String table, TableInfo tableInfo) throws SQLException{

--- a/src/main/java/pz/tool/jdbcimage/main/DBFacadeListener.java
+++ b/src/main/java/pz/tool/jdbcimage/main/DBFacadeListener.java
@@ -1,5 +1,7 @@
 package pz.tool.jdbcimage.main;
 
+import pz.tool.jdbcimage.ResultSetInfo;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collections;
@@ -40,4 +42,6 @@ public interface DBFacadeListener {
     void importFinished();
     void beforeImportTable(Connection con, String table, DBFacade.TableInfo tableInfo) throws SQLException;
     void afterImportTable(Connection con, String table, DBFacade.TableInfo tableInfo) throws SQLException;
+    default void beforeImportTableData(Connection con, String table, DBFacade.TableInfo tableInfo, ResultSetInfo fileInfo) throws SQLException {
+    }
 }

--- a/src/main/java/pz/tool/jdbcimage/main/SingleTableImport.java
+++ b/src/main/java/pz/tool/jdbcimage/main/SingleTableImport.java
@@ -85,7 +85,15 @@ public class SingleTableImport extends MainToolBase{
 			// import data
 			tableInfo.setTableColumns(actualColumns);
 			dbFacade.beforeImportTable(con, tableName, tableInfo);
-			ResultProducerRunner runner = new ResultProducerRunner(producer, new DbImportResultConsumer(tableName, con, dbFacade, actualColumns));
+			DbImportResultConsumer consumer = new DbImportResultConsumer(tableName, con, dbFacade, actualColumns);
+			consumer.setNotifyOnStartFn(fileInfo -> {
+				try {
+					dbFacade.beforeImportTableData(con, tableName, tableInfo, fileInfo);
+				} catch(SQLException e){
+					throw new RuntimeException(e);
+				}
+			});
+			ResultProducerRunner runner = new ResultProducerRunner(producer, consumer);
 			long rows = runner.run();
 			dbFacade.afterImportTable(con, tableName, tableInfo);
 


### PR DESCRIPTION
Closes #16

This PR modifies MSSQL DBFacade so that it enables `identity insert` only when inserting data to an identity column. Before this PR, `identity insert` was enabled whenever the database table has an identity column.